### PR TITLE
Add tls features with native tls as default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,16 @@ async-tungstenite = { version = "0.16.1", features = ["tokio-runtime"] }
 futures-util = "0.3.19"
 http = "0.2.6"
 log = "0.4.14"
-reqwest = { version = "0.11.8", features = ["json"] }
+reqwest = { version = "0.11.8", features = ["json"], default-features = false }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 thiserror = "1.0.30"
+
+[features]
+default = ["native-tls"]
+native-tls = ["async-tungstenite/tokio-native-tls", "reqwest/native-tls"]
+rustls-native-certs = ["async-tungstenite/tokio-rustls-native-certs", "reqwest/rustls-tls-native-roots"]
+rustls = ["async-tungstenite/tokio-rustls-webpki-roots", "reqwest/rustls-tls"]
 
 [dev-dependencies]
 mockito = "0.30.0"


### PR DESCRIPTION
Hello! Thank you for creating this crate. This PR adds native-tls as a default feature for async-tungstenite. It also makes it possible to pick rustls as the tls provider for reqwest and async-tungstenite, with either webpki or native certs.