### PR TITLE
ws-keep-alive feature pings server intermittently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,9 @@ homepage = "https://github.com/Celeo/mattermost_api"
 repository = "https://github.com/Celeo/mattermost_api"
 documentation = "https://docs.rs/mattermost_api"
 license = "MIT OR Apache-2.0"
-exclude = [
-  ".github"
-]
-keywords = [
-  "mattermost"
-]
-categories = [
-  "api-bindings"
-]
+exclude = [".github"]
+keywords = ["mattermost"]
+categories = ["api-bindings"]
 
 [dependencies]
 async-trait = "0.1.52"
@@ -28,11 +22,16 @@ reqwest = { version = "0.11.8", features = ["json"], default-features = false }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 thiserror = "1.0.30"
+tokio = { version = "1.15.0", features = ["full"], optional = true }
 
 [features]
-default = ["native-tls"]
+default = ["native-tls", "ws-keep-alive"]
+ws-keep-alive = ["dep:tokio"]
 native-tls = ["async-tungstenite/tokio-native-tls", "reqwest/native-tls"]
-rustls-native-certs = ["async-tungstenite/tokio-rustls-native-certs", "reqwest/rustls-tls-native-roots"]
+rustls-native-certs = [
+  "async-tungstenite/tokio-rustls-native-certs",
+  "reqwest/rustls-tls-native-roots",
+]
 rustls = ["async-tungstenite/tokio-rustls-webpki-roots", "reqwest/rustls-tls"]
 
 [dev-dependencies]


### PR DESCRIPTION
If the new feature is enabled, the client will ping the server every 30 seconds to keep the connection alive. I kept it feature-locked as it requires tokio as a new dependency, but added it to default since I believe most people will want this.

I broke out a couple of functions to make them easier to compose, but not a lot of logic is changed.

Closes #3 